### PR TITLE
Add grass, tree and water tiles

### DIFF
--- a/data/maps.json
+++ b/data/maps.json
@@ -1,25 +1,200 @@
 {
-  "start": { "x": 1, "y": 1 },
-
+  "start": {
+    "x": 1,
+    "y": 1
+  },
   "maps": [
     {
       "name": "Grasslands",
       "width": 12,
       "height": 12,
       "tiles": [
-        
-        [1,1,1,1,1,1,1,1,1,1,1,1],
-        [1,0,0,0,0,0,0,0,0,0,{ "type": "battle", "group": ["blazehound"], "name": "Blazehound Den" },1],
-        [1,0,1,1,1,0,1,1,1,0,0,1],
-        [1,0,0,0,0,0,0,0,1,0,0,1],
-        [1,1,1,0,1,1,1,0,1,1,0,1],
-        [1,0,0,0,0,0,1,0,0,0,0,1],
-        [1,0,1,1,1,0,1,1,1,1,0,1],
-        [1,0,0,0,1,0,0,0,0,1,0,1],
-        [1,1,0,0,1,1,1,1,0,1,0,1],
-        [1,0,0,0,0,0,0,{ "type": "battle", "group": ["shardfang"], "name": "Shardfang Nest" },0,0,0,1],
-        [1,0,1,1,1,1,1,1,1,1,{ "type": "battle", "group": ["zingrief"], "name": "Zingrief Outpost" },1],
-        [1,1,1,1,1,1,1,1,1,1,1,1]
+        [
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          {
+            "type": "battle",
+            "group": [
+              "blazehound"
+            ],
+            "name": "Blazehound Den"
+          },
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "tree",
+          "tree",
+          "tree",
+          "grass",
+          "tree",
+          "tree",
+          "tree",
+          "grass",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "tree",
+          "grass",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "tree",
+          "tree",
+          "grass",
+          "tree",
+          "tree",
+          "tree",
+          "grass",
+          "tree",
+          "tree",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "grass",
+          "water",
+          "water",
+          "water",
+          "tree",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "tree",
+          "water",
+          "water",
+          "water",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "grass",
+          "grass",
+          "tree",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "tree",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "tree",
+          "grass",
+          "grass",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "grass",
+          "tree",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          "grass",
+          {
+            "type": "battle",
+            "group": [
+              "shardfang"
+            ],
+            "name": "Shardfang Nest"
+          },
+          "grass",
+          "grass",
+          "grass",
+          "tree"
+        ],
+        [
+          "tree",
+          "grass",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          {
+            "type": "battle",
+            "group": [
+              "zingrief"
+            ],
+            "name": "Zingrief Outpost"
+          },
+          "tree"
+        ],
+        [
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree",
+          "tree"
+        ]
       ]
     }
   ]

--- a/game.js
+++ b/game.js
@@ -61,17 +61,21 @@ function renderMap() {
         img.src = "assets/snealer_chibi.png"; // Adjust for your hero
         img.alt = "Player";
         tile.appendChild(img);
-      } else if (value === 1) {
-        // Wall tile
-        tile.classList.add("wall");
-        tile.textContent = "#";
+      } else if (value === 1 || value === "tree") {
+        // Tree (non-walkable)
+        tile.classList.add("tree");
+        tile.textContent = "T";
+      } else if (value === "water") {
+        // Water (non-walkable)
+        tile.classList.add("water");
+        tile.textContent = "~";
       } else if (typeof value === "object" && value.type === "battle") {
         // Enemy/battle tile
         tile.classList.add("enemy");
         tile.textContent = "E";
       } else {
-        // Default floor tile
-        tile.classList.add("floor");
+        // Default grass tile
+        tile.classList.add("grass");
         tile.textContent = ".";
       }
 
@@ -103,12 +107,11 @@ function handleTileClick(targetX, targetY) {
     return;
   }
 
-  // Get what's in the tile (wall, floor, or battle object)
+  // Get what's in the tile (terrain or battle object)
   const tile = currentMap.tiles[targetY][targetX];
-
-  // If it's a wall (value = 1), block movement
-  if (tile === 1) {
-    console.log("Cannot move — wall is blocking.");
+  // Block movement on trees and water
+  if (tile === 1 || tile === "tree" || tile === "water") {
+    console.log("Cannot move — terrain is blocking.");
     return;
   }
 
@@ -129,7 +132,7 @@ function handleTileClick(targetX, targetY) {
     enterBattle(tile.group);
 
     // Clear the battle tile so it's not triggered again
-    currentMap.tiles[targetY][targetX] = 0;
+    currentMap.tiles[targetY][targetX] = "grass";
   }
 
   // Refresh the map view to reflect the move
@@ -153,7 +156,7 @@ window.addEventListener("keydown", e => {
 
   const targetTile = currentMap.tiles[newY][newX];
 
-  if (targetTile === 1) return; // wall
+  if (targetTile === 1 || targetTile === "tree" || targetTile === "water") return; // blocked terrain
 
   playerPosition = { x: newX, y: newY };
 
@@ -161,7 +164,7 @@ window.addEventListener("keydown", e => {
   if (typeof targetTile === "object" && targetTile.type === "battle") {
     if (targetTile.name) showZoneInfo(targetTile.name);
     enterBattle(targetTile.group);
-    currentMap.tiles[newY][newX] = 0;
+    currentMap.tiles[newY][newX] = "grass";
   }
 
   renderMap();

--- a/style.css
+++ b/style.css
@@ -43,8 +43,14 @@ body {
 .tile.wall {
   background-color: #333;
 }
-.tile.floor {
-  background-color: #eee;
+.tile.grass {
+  background-color: #3fa34d;
+}
+.tile.tree {
+  background-color: #175c27;
+}
+.tile.water {
+  background-color: #4da6ff;
 }
 .tile.enemy {
   background-color: crimson;


### PR DESCRIPTION
## Summary
- style walkable tiles as grass
- support trees and water as new tile types
- prevent movement through trees and water
- convert map data to use `grass`, `tree` and `water`

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_6847292fa1d48331b89e04d3973d068c